### PR TITLE
fix(sniplet): #CO-1770 fix display bug of last modified page when sniplet

### DIFF
--- a/src/main/resources/public/ts/behaviours.ts
+++ b/src/main/resources/public/ts/behaviours.ts
@@ -3,6 +3,7 @@ import { Behaviours, http, _, moment, notify, template, model, idiom as lang } f
 declare const window: any;
 console.log('wiki behaviours loaded');
 
+var defaultPagination = 10;
 var isWikiApplication = function() {
 	return (window.location.pathname === '/wiki');
 };
@@ -685,13 +686,14 @@ wikiNamespace.Wiki.prototype.listAllPages = function(callback) {
 };
 
 wikiNamespace.Wiki.prototype.setLastPages = function() {
+	let pagination = window.pagination ? window.pagination : defaultPagination;
 	var dateArray = _.chain(this.pages.all).pluck("modified").compact().value();
 	if(dateArray && dateArray.length > 0) {
-		// get the last 5 modified pages
+		// get the last modified pages using pagination config or defaultpagination when sniplet.
 		this.lastPages = _.chain(this.pages.all)
 							.filter(function(page){ return page.modified && page.modified.$date; })
 							.sortBy(function(page){ return page.modified.$date; })
-							.last(window.pagination)
+							.last(pagination)
 							.reverse()
 							.value();
 	}


### PR DESCRIPTION
## Describe your changes
The information of pagination configuration is not provided when wiki is in sniplet mode.
So, a check in front file behaviour.ts was added to verify if variable window.pagination is defined. If not, a defaultPagination value was set.
As seen with Fanny, the defaultPagination value for the sniplet was set to 10 whereas the default pagination value is set to 5 in wiki module configuration. This value is assumed as a wanted value and may be changed later.
## Checklist tests
Go to pages module and add a new page. As sniplet, select wiki and create several pages. It must now display the 10 last modified pages.
## Issue ticket number and link
[CO-1770](https://jira.support-ent.fr/browse/CO-1770)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

