### PR TITLE
fix: #WB2-1526, disable checkbox and btn in RevisionModal if page is lastVersion

### DIFF
--- a/frontend/src/features/page/RevisionModal/RevisionModal.test.tsx
+++ b/frontend/src/features/page/RevisionModal/RevisionModal.test.tsx
@@ -37,7 +37,7 @@ vi.mock('~/services', () => ({
 vi.mock('~/hooks/useCheckableTable');
 
 const mockRevisionTableHookValue = {
-  selectedItems: [mockRevision[0]._id, mockRevision[1]._id],
+  selectedItems: [mockRevision[1]._id, mockRevision[2]._id],
   allItemsSelected: false,
   isIndeterminate: false,
   handleOnSelectAllItems: mocks.handleOnSelectAllItems,
@@ -121,7 +121,7 @@ describe('RevisionModal', () => {
   it('should disable the compare button when there are less than 2 selected items', async () => {
     vi.mocked(useCheckableTable).mockReturnValue({
       ...mockRevisionTableHookValue,
-      selectedItems: [mockRevision[0]._id],
+      selectedItems: [mockRevision[1]._id],
     });
 
     render(<RevisionModal />);
@@ -142,20 +142,39 @@ describe('RevisionModal', () => {
   it('should enable the Restore button when one item is selected', async () => {
     vi.mocked(useCheckableTable).mockReturnValue({
       ...mockRevisionTableHookValue,
-      selectedItems: [mockRevision[0]._id],
+      selectedItems: [mockRevision[1]._id],
     });
 
     render(<RevisionModal />);
 
     const user = userEvent.setup();
-    const checkbox = screen.getAllByRole('checkbox')[1];
+    const checkbox = screen.getByTestId(`checkbox-${mockRevision[1]._id}`);
     const restoreButton = screen.getByTestId('restore-button');
 
     await user.click(checkbox);
 
     expect(checkbox).toBeChecked();
-    expect(mocks.handleOnSelectItem).toHaveBeenCalledWith(mockRevision[0]._id);
+    expect(mocks.handleOnSelectItem).toHaveBeenCalledWith(mockRevision[1]._id);
     expect(restoreButton).not.toBeDisabled();
+  });
+
+  it('should disable the Restore button when version is hidden and user has no right', async () => {
+    vi.mocked(useCheckableTable).mockReturnValue({
+      ...mockRevisionTableHookValue,
+      selectedItems: [mockRevision[2]._id],
+    });
+
+    render(<RevisionModal />);
+
+    const user = userEvent.setup();
+    const checkbox = screen.getByTestId(`checkbox-${mockRevision[2]._id}`);
+    const restoreButton = screen.getByTestId('restore-button');
+
+    await user.click(checkbox);
+
+    expect(checkbox).toBeChecked();
+    expect(mocks.handleOnSelectItem).toHaveBeenCalledWith(mockRevision[2]._id);
+    expect(restoreButton).toBeDisabled();
   });
 
   it('should have no checkbox checked', () => {
@@ -175,6 +194,7 @@ describe('RevisionModal', () => {
 
     const user = userEvent.setup();
     const checkbox = screen.getByTestId('th-checkbox');
+
     await user.click(checkbox);
 
     expect(checkbox).toBeChecked();
@@ -185,10 +205,10 @@ describe('RevisionModal', () => {
     render(<RevisionModal />);
 
     const user = userEvent.setup();
-    const checkbox = screen.getAllByRole('checkbox')[1];
+    const checkbox = screen.getAllByRole('checkbox')[2];
     await user.click(checkbox);
 
     expect(checkbox).toBeChecked();
-    expect(mocks.handleOnSelectItem).toHaveBeenCalledWith(mockRevision[0]._id);
+    expect(mocks.handleOnSelectItem).toHaveBeenCalledWith(mockRevision[1]._id);
   });
 });

--- a/frontend/src/features/page/RevisionModal/RevisionModal.tsx
+++ b/frontend/src/features/page/RevisionModal/RevisionModal.tsx
@@ -80,39 +80,45 @@ const RevisionModal = () => {
               </Table.Tr>
             </Table.Thead>
             <Table.Tbody>
-              {data?.map((item) => (
-                <Table.Tr key={item._id}>
-                  <Table.Td>
-                    <Checkbox
-                      data-testid={`checkbox-${item._id}`}
-                      checked={selectedItems.includes(item._id)}
-                      onChange={() => {
-                        handleOnSelectItem(item._id);
-                      }}
-                    />
-                  </Table.Td>
-                  <Table.Td>{item.username}</Table.Td>
-                  <Table.Td>
-                    <Badge
-                      variant={{
-                        type: 'content',
-                        background: true,
-                        level: item.isVisible ? 'warning' : 'info',
-                      }}
-                    >
-                      {item.isVisible
-                        ? t('wiki.table.body.visible')
-                        : t('wiki.table.body.invisible')}
-                    </Badge>
-                  </Table.Td>
-                  <Table.Td className="fst-italic text-gray-700">
-                    {formatDate(item.date)}
-                  </Table.Td>
-                  <Table.Td>
-                    <Button variant="ghost">{t('wiki.table.body.btn')}</Button>
-                  </Table.Td>
-                </Table.Tr>
-              ))}
+              {data?.map((item, index) => {
+                const isLastVersion = index === 0;
+
+                return (
+                  <Table.Tr key={item._id}>
+                    <Table.Td>
+                      <Checkbox
+                        data-testid={`checkbox-${item._id}`}
+                        checked={selectedItems.includes(item._id)}
+                        onChange={() => {
+                          handleOnSelectItem(item._id);
+                        }}
+                      />
+                    </Table.Td>
+                    <Table.Td>{item.username}</Table.Td>
+                    <Table.Td>
+                      <Badge
+                        variant={{
+                          type: 'content',
+                          background: true,
+                          level: item.isVisible ? 'warning' : 'info',
+                        }}
+                      >
+                        {item.isVisible
+                          ? t('wiki.table.body.visible')
+                          : t('wiki.table.body.invisible')}
+                      </Badge>
+                    </Table.Td>
+                    <Table.Td className="fst-italic text-gray-700">
+                      {formatDate(item.date)}
+                    </Table.Td>
+                    <Table.Td>
+                      <Button variant="ghost" disabled={isLastVersion}>
+                        {t('wiki.table.body.btn')}
+                      </Button>
+                    </Table.Td>
+                  </Table.Tr>
+                );
+              })}
             </Table.Tbody>
           </Table>
         )}

--- a/frontend/src/features/page/RevisionModal/useRevisionModal.ts
+++ b/frontend/src/features/page/RevisionModal/useRevisionModal.ts
@@ -31,10 +31,16 @@ export const useRevisionModal = ({
       ? data?.find((revision) => revision._id === selectedItems[0])
       : undefined;
 
+  const isLastVersion =
+    selectedItems.length === 1 && data?.[0]?._id === selectedItems[0];
+
   const isSelectedItemVisible = findSelectedItem?.isVisible ?? false;
 
   const disabledRestoreButton =
-    selectedItems.length !== 1 || (!isSelectedItemVisible && !canManage);
+    selectedItems.length !== 1 ||
+    (!isSelectedItemVisible && !canManage) ||
+    isLastVersion;
+
   const disabledVersionComparison =
     selectedItems.length < 2 || selectedItems.length > 2;
 
@@ -43,6 +49,7 @@ export const useRevisionModal = ({
     openVersionsModal,
     canManage,
     t,
+    isLastVersion,
     disabledRestoreButton,
     disabledVersionComparison,
     formatDate,

--- a/frontend/src/mocks/index.ts
+++ b/frontend/src/mocks/index.ts
@@ -155,8 +155,21 @@ export const mockRevision: Revision[] = [
     pageId: '6684fd',
     userId: '2875315d',
     username: 'Author',
+    isVisible: true,
+    title: 'title 2',
+    content: '',
+    date: {
+      $date: 1720184598119,
+    },
+  },
+  {
+    _id: 'd7e68db2',
+    wikiId: '6ef1343b',
+    pageId: '6684fd',
+    userId: '2875315d',
+    username: 'Author',
     isVisible: false,
-    title: 'title',
+    title: 'title 3',
     content: '',
     date: {
       $date: 1720184598119,


### PR DESCRIPTION
## Describe your changes

- Disable btn to redirect to version page if the page is the latest version
- Disable restore btn if the page is the latest version

## Checklist tests

- Changes tests to check correctly when a contributor can't restore a non visible page

## Issue ticket number and link

https://edifice-community.atlassian.net/browse/WB2-1526

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

