### PR TITLE
feat: #WB2-1534, add access to pages list in sidebar and dropdown

### DIFF
--- a/frontend/src/features/wiki/DropdownTreeview.tsx
+++ b/frontend/src/features/wiki/DropdownTreeview.tsx
@@ -2,11 +2,14 @@ import { TextPage } from '@edifice-ui/icons';
 import {
   Dropdown,
   IconButtonProps,
+  Menu,
   TreeData,
   TreeView,
 } from '@edifice-ui/react';
 import { ID } from 'edifice-ts-client';
 import { RefAttributes } from 'react';
+import { useMenu } from '~/hooks/useMenu';
+import { useTreeActions } from '~/store';
 
 export const DropdownTreeview = ({
   treeData,
@@ -19,6 +22,11 @@ export const DropdownTreeview = ({
   onTreeItemClick: (pageId: ID) => void;
   onTreeItemAction?: (pageId: ID) => void;
 }) => {
+  const { setSelectedNodeId } = useTreeActions();
+  const { data: menu, handleOnMenuClick } = useMenu({
+    onMenuClick: setSelectedNodeId,
+  });
+
   return (
     <div className="dropdown-treeview w-100 mb-16">
       <Dropdown block>
@@ -36,6 +44,18 @@ export const DropdownTreeview = ({
                 setVisible(false);
               }}
             >
+              <Menu label={menu.children}>
+                <Menu.Item>
+                  <Menu.Button
+                    onClick={handleOnMenuClick}
+                    leftIcon={menu.leftIcon}
+                    selected={menu.selected}
+                  >
+                    {menu.children}
+                  </Menu.Button>
+                </Menu.Item>
+              </Menu>
+              <Dropdown.Separator />
               <TreeView
                 data={treeData}
                 showIcon={false}

--- a/frontend/src/hooks/useMenu.tsx
+++ b/frontend/src/hooks/useMenu.tsx
@@ -8,7 +8,11 @@ import {
   useParams,
 } from 'react-router-dom';
 
-export const useMenu = () => {
+export const useMenu = ({
+  onMenuClick,
+}: {
+  onMenuClick: (value: string) => void;
+}) => {
   const params = useParams();
   const location = useLocation();
   const navigate = useNavigate();
@@ -28,5 +32,10 @@ export const useMenu = () => {
     selected: isSelected('/id/:wikiId/pages') ?? false,
   };
 
-  return data;
+  const handleOnMenuClick = () => {
+    onMenuClick('');
+    data.onClick();
+  };
+
+  return { data, handleOnMenuClick };
 };

--- a/frontend/src/routes/wiki/index.tsx
+++ b/frontend/src/routes/wiki/index.tsx
@@ -1,8 +1,15 @@
-import { checkUserRight, Grid, Menu, TreeView } from '@edifice-ui/react';
+import {
+  checkUserRight,
+  Dropdown,
+  Grid,
+  Menu,
+  TreeView,
+} from '@edifice-ui/react';
 import { QueryClient } from '@tanstack/react-query';
 import { useMediaQuery } from '@uidotdev/usehooks';
 import clsx from 'clsx';
 import { ID, odeServices } from 'edifice-ts-client';
+import { useEffect } from 'react';
 import {
   LoaderFunctionArgs,
   Outlet,
@@ -25,7 +32,6 @@ import {
   useTreeData,
 } from '~/store/treeview';
 import './index.css';
-import { useEffect } from 'react';
 
 export const loader =
   (queryClient: QueryClient) =>
@@ -58,7 +64,9 @@ export const Index = () => {
   const { setSelectedNodeId } = useTreeActions();
   const match = useMatch('/id/:wikiId');
   const isSmallDevice = useMediaQuery('only screen and (max-width: 1024px)');
-  const menu = useMenu();
+  const { data: menu, handleOnMenuClick } = useMenu({
+    onMenuClick: setSelectedNodeId,
+  });
 
   const { data } = useGetWiki(params.wikiId!);
 
@@ -80,11 +88,6 @@ export const Index = () => {
 
   const handleOnTreeItemClick = (pageId: ID) => {
     navigate(`/id/${data?._id}/page/${pageId}`);
-  };
-
-  const handleOnMenuClick = () => {
-    setSelectedNodeId('');
-    menu.onClick();
   };
 
   const handleOnTreeItemCreateChildren = (pageId: ID) => {
@@ -112,7 +115,7 @@ export const Index = () => {
             className="border-end pt-16 pe-16 d-none d-lg-block"
             as="aside"
           >
-            <Menu label={data ? data.title : ''}>
+            <Menu label={menu.children}>
               <Menu.Item>
                 <Menu.Button
                   onClick={handleOnMenuClick}
@@ -123,6 +126,7 @@ export const Index = () => {
                 </Menu.Button>
               </Menu.Item>
             </Menu>
+            <Dropdown.Separator />
             {!isOnlyRead && <NewPage />}
             {treeData && (
               <TreeView


### PR DESCRIPTION
## Describe your changes

- Add pages list btn in dropdown treeview
- Add a separator as indicated in figma design
- Move `handleOnMenuClick` inside hook and pass setSelectedNodeId as callback

## Checklist tests

## Issue ticket number and link

https://edifice-community.atlassian.net/browse/WB2-1534

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

