### PR TITLE
feat: #WB2-1891, update page backend jsonshema for page creation and update

### DIFF
--- a/backend/src/main/java/net/atos/entng/wiki/service/WikiService.java
+++ b/backend/src/main/java/net/atos/entng/wiki/service/WikiService.java
@@ -21,6 +21,7 @@ package net.atos.entng.wiki.service;
 
 import java.util.Optional;
 
+import io.vertx.core.Future;
 import io.vertx.core.http.HttpServerRequest;
 import org.entcore.common.user.UserInfos;
 import io.vertx.core.Handler;
@@ -54,7 +55,7 @@ public interface WikiService {
 	public void createPage(UserInfos user, String wikiId, JsonObject page, HttpServerRequest request
 			, Handler<Either<String, JsonObject>> handler);
 
-	public void updatePage(UserInfos user, String idWiki, JsonObject page, HttpServerRequest request, Handler<Either<String, JsonObject>> handler);
+	public void updatePage(UserInfos user, String idWiki, String idPage, JsonObject pagePayload, HttpServerRequest request, Handler<Either<String, JsonObject>> handler);
 
 	public void deletePage(UserInfos user, String idWiki, String idPage,
 			Handler<Either<String, JsonObject>> handler);
@@ -80,8 +81,8 @@ public interface WikiService {
 	public void updateComment(String idWiki, String idPage, String idComment, String comment,
 							  Handler<Either<String, JsonObject>> handler);
 
-	public void createRevision(String wikiId, String pageId, UserInfos user,
-			String pageTitle, String pageContent, boolean isVisible, Handler<Either<String, JsonObject>> handler);
+	public Future<Void> createRevision(String wikiId, String pageId, UserInfos user, String pageTitle, String pageContent,
+										 boolean isVisible, Integer position);
 
 	public void listRevisions(String wikiId, String pageId, Handler<Either<String, JsonArray>> handler);
 

--- a/backend/src/main/resources/jsonschema/pageCreate.json
+++ b/backend/src/main/resources/jsonschema/pageCreate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "PageCreate",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "title": { "type": "string" },
     "content": { "type": "string" },
@@ -11,7 +11,6 @@
     "isVisible": { "type": "boolean" },
     "position": { "type": "number" }
   },
-  "required": [
-    "title"
-  ]
+  "additionalProperties": false,
+  "required": ["title"]
 }

--- a/backend/src/main/resources/jsonschema/pageUpdate.json
+++ b/backend/src/main/resources/jsonschema/pageUpdate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "PageUpdate",
+  "type": "object",
+  "properties": {
+    "title": { "type": "string" },
+    "content": { "type": "string" },
+    "parentId": { "type":  ["string", "null"] },
+    "isIndex": { "type": "boolean"},
+    "wasIndex": { "type": "boolean" },
+    "isVisible": { "type": "boolean" },
+    "position": { "type": "number" }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Describe your changes

Différenciation entre le schéma json de validation pour la création et la modification d'une page.

Pour la création d'une page, le champ "title" est obligatoire dans le payload de la requête de création.

Pour la modification d'une page, aucun champ n'est obligatoire, on passe les champs que l'on veut modifier dans le payload. Par exemple si on veut modifier que le titre d'une page, on passe :
`{"title": "updated title"}`

Ces modifications de schéma ont entrainé du refacto des APIs createPage et updatePage.

## Checklist tests

## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

