### PR TITLE
fix: #WB2-1893, add react-hook-form to create/edit page

### DIFF
--- a/frontend/src/features/page/ConfirmVisibilityModal/index.tsx
+++ b/frontend/src/features/page/ConfirmVisibilityModal/index.tsx
@@ -2,15 +2,12 @@ import { Button, Modal, useOdeClient } from '@edifice-ui/react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Form, useActionData } from 'react-router-dom';
+import { FormPageDataProps } from '~/hooks/useFormPage';
 import { Page } from '~/models';
 import { useOpenConfirmVisibilityModal, useWikiActions } from '~/store';
 
 export default function ConfirmVisibilityModal({ page }: { page: Page }) {
-  const actionData = useActionData() as {
-    title: string;
-    content: string;
-    isVisible: boolean;
-  };
+  const actionData = useActionData() as FormPageDataProps;
 
   const { appCode } = useOdeClient();
   const { t } = useTranslation(appCode);
@@ -42,7 +39,6 @@ export default function ConfirmVisibilityModal({ page }: { page: Page }) {
           {t('wiki.page.editform.cancel')}
         </Button>
         <Form
-          action="confirmVisibility"
           method="post"
           onSubmit={() => setOpenConfirmVisibilityModal(false)}
         >
@@ -51,6 +47,7 @@ export default function ConfirmVisibilityModal({ page }: { page: Page }) {
             name="actionData"
             value={JSON.stringify(actionData)}
           />
+          <input type="hidden" name="isConfirmVisibilityForm" value="true" />
           <Button
             type="submit"
             color="primary"

--- a/frontend/src/hooks/useCancelPage.ts
+++ b/frontend/src/hooks/useCancelPage.ts
@@ -6,20 +6,20 @@ import {
 } from 'react-router-dom';
 import { Page } from '~/models';
 
-export const useCancelPage = (isModified: boolean, page?: Page) => {
+export const useCancelPage = (isDirty: boolean, page?: Page) => {
   const params = useParams();
 
   const navigate = useNavigate();
 
   const blocker = useBlocker(
     ({ currentLocation, nextLocation }) =>
-      isModified && currentLocation !== nextLocation
+      isDirty && currentLocation.pathname !== nextLocation.pathname
   );
 
   const isBlocked = blocker.state === 'blocked';
 
   useBeforeUnload((event) => {
-    if (isModified) {
+    if (isDirty) {
       event.preventDefault();
     }
   });

--- a/frontend/src/hooks/useFormPage.tsx
+++ b/frontend/src/hooks/useFormPage.tsx
@@ -1,17 +1,21 @@
 import { EditorRef } from '@edifice-ui/editor';
-import { useToggle } from '@uidotdev/usehooks';
-import { useCallback, useRef, useState } from 'react';
-import { useLocation, useNavigation, useParams } from 'react-router-dom';
+import { useCallback, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+import { useLocation, useParams, useSubmit } from 'react-router-dom';
 import { Page } from '~/models';
 import { useGetWiki } from '~/services';
 import { findPage } from '~/utils/findPage';
 
+export type FormPageDataProps = {
+  title: string;
+  isVisible: boolean;
+  content: string;
+};
+
 export const useFormPage = (page?: Page) => {
-  const navigation = useNavigation();
   const location = useLocation();
   const editorRef = useRef<EditorRef>(null);
   const params = useParams();
-
   const { data: wikiData } = useGetWiki(params.wikiId!);
 
   const isSubPage: boolean =
@@ -40,54 +44,20 @@ export const useFormPage = (page?: Page) => {
     return isVisible;
   }, [page, params, editionMode, isSubPage, wikiData]);
 
-  const [content, setContent] = useState(page?.content ?? '');
-  const [contentTitle, setContentTitle] = useState(page?.title ?? '');
-  const [isVisible, toggle] = useToggle(getDefaultVisibleValue());
-  const [isModified, setIsModified] = useState(false);
-  const [isDisableButton, setIsDisableButton] = useState(true);
+  const {
+    control,
+    register,
+    handleSubmit,
+    formState: { isSubmitting, isDirty, isValid },
+  } = useForm<FormPageDataProps>({
+    defaultValues: {
+      title: page?.title,
+      isVisible: getDefaultVisibleValue(),
+      content: page?.content,
+    },
+  });
 
-  const isSubmitting = navigation.state === 'submitting';
-
-  const isModify = useCallback(() => {
-    if (!page) return !!content || !!contentTitle;
-    if (content) {
-      return (
-        page.content !== content ||
-        page.title !== contentTitle ||
-        page.isVisible !== isVisible
-      );
-    }
-    return false;
-  }, [content, contentTitle, isVisible, page]);
-
-  const updateModificationState = () => {
-    if (isModify()) {
-      setIsModified(true);
-      setIsDisableButton(false);
-    }
-  };
-
-  const handleOnTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setContentTitle(event.target.value);
-    updateModificationState();
-  };
-
-  const handleOnToggleChange = () => {
-    toggle();
-    updateModificationState();
-  };
-
-  const handleOnContentChange = ({ editor }: any) => {
-    const htmlContent = editor.getHTML();
-    setContent(htmlContent);
-    updateModificationState();
-  };
-
-  const handleOnReset = () => {
-    if (contentTitle.length > 0) {
-      setIsModified(false);
-    }
-  };
+  const submit = useSubmit();
 
   const disableToggle = useCallback(() => {
     if (isSubPage) {
@@ -101,20 +71,45 @@ export const useFormPage = (page?: Page) => {
     return false;
   }, [editionMode, isSubPage, wikiData, page, params]);
 
+  const handleEditorChange = (
+    { editor }: any,
+    onChange: (...event: any[]) => void
+  ) => {
+    const updatedContent = editor.getHTML();
+    onChange(updatedContent);
+  };
+
+  const onSubmit = (data: any) => {
+    submit(data, {
+      method: 'post',
+    });
+  };
+
+  const label = isSubPage
+    ? 'wiki.createform.subpage.label'
+    : 'wiki.createform.page.label';
+
+  const placeholder = isSubPage
+    ? 'wiki.createform.subpage.placeholder'
+    : 'wiki.createform.page.placeholder';
+
+  const save = isSubPage
+    ? 'wiki.createform.subpage.save'
+    : 'wiki.createform.page.save';
+
   return {
-    handleOnContentChange,
-    handleOnToggleChange,
-    handleOnTitleChange,
-    handleOnReset,
+    register,
+    handleEditorChange,
+    handleSubmit,
+    onSubmit,
     disableToggle,
-    getDefaultVisibleValue,
-    isDisableButton,
+    control,
     isSubmitting,
-    contentTitle,
-    isModified,
+    isDirty,
+    isValid,
     editorRef,
-    isVisible,
-    content,
-    isSubPage,
+    label,
+    placeholder,
+    save,
   };
 };

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -7,7 +7,7 @@ import { PageError } from '~/routes/errors';
 import { NotFound } from '~/routes/errors/not-found';
 import { Page, action as deleteAction, loader as pageLoader } from './page';
 import { CreatePage, action as createAction } from './page/create';
-import { EditPage, confirmVisibilityAction, editAction } from './page/edit';
+import { EditPage, editAction } from './page/edit';
 import { Pages, loader as pagesLoader } from './page/list';
 import { Index, loader as wikiLoader } from './wiki';
 
@@ -56,11 +56,6 @@ export const routes = (queryClient: QueryClient): RouteObject[] => [
             path: 'page/:pageId/edit',
             element: <EditPage />,
             action: editAction(queryClient),
-          },
-          {
-            path: 'page/:pageId/edit/confirmVisibility',
-            element: <EditPage />,
-            action: confirmVisibilityAction(queryClient),
           },
           {
             path: 'page/:pageId/subpage/create',

--- a/frontend/src/routes/page/create.tsx
+++ b/frontend/src/routes/page/create.tsx
@@ -2,15 +2,16 @@ import { QueryClient } from '@tanstack/react-query';
 import { ActionFunctionArgs, redirect, useLocation } from 'react-router-dom';
 import { FormPage } from '~/features/page/FormPage';
 import { wikiQueryOptions, wikiService } from '~/services';
+import { getFormValue } from '~/utils/getFormValue';
 
 export const action =
   (queryClient: QueryClient) =>
   async ({ params, request }: ActionFunctionArgs) => {
     const formData = await request.formData();
 
-    const title = formData.get('title') as string;
-    const content = formData.get('content') as string;
-    const isVisible = formData.get('isVisible') === 'on';
+    const title = getFormValue(formData, 'title');
+    const content = getFormValue(formData, 'content');
+    const isVisible = getFormValue(formData, 'isVisible') === 'true';
 
     const data = await wikiService.createPage({
       wikiId: params.wikiId!,

--- a/frontend/src/utils/getFormValue.ts
+++ b/frontend/src/utils/getFormValue.ts
@@ -1,0 +1,2 @@
+export const getFormValue = (formData: FormData, key: string) =>
+  formData.get(key) as string;


### PR DESCRIPTION
## Describe your changes

Add react-hook-form to page create/edit form to handle inputs changes and form submit button disable state.

Refactor the edit action: only one action for edit form and confirm visibility modal form

## Checklist tests

## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

