### PR TITLE
fix: #WB2-1925, redirect to a visible default page

### DIFF
--- a/frontend/src/hooks/useRedirectDefaultPage.ts
+++ b/frontend/src/hooks/useRedirectDefaultPage.ts
@@ -1,26 +1,25 @@
 import { useEffect } from 'react';
 import { useMatch, useNavigate, useParams } from 'react-router-dom';
 import { useGetWiki } from '~/services';
+import { useUserRights } from '~/store';
+import { findDefaultPage } from '~/utils/findDefaultPage';
 
 export const useRedirectDefaultPage = () => {
   const params = useParams();
   const navigate = useNavigate();
   const match = useMatch('/id/:wikiId');
+  const userRights = useUserRights();
 
-  const { data } = useGetWiki(params.wikiId!);
+  const { data: wiki } = useGetWiki(params.wikiId!);
 
   useEffect(() => {
-    if (match && data && !!data.pages.length) {
-      const findIndexPage = data.pages.find((page) => page._id === data.index);
-      const firstPage = data.pages[0];
+    if (match && wiki && !!wiki.pages.length) {
+      const defaultPage = findDefaultPage(wiki, userRights);
 
-      if (findIndexPage) {
-        const pageId = findIndexPage?._id;
-        return navigate(`/id/${data?._id}/page/${pageId}`);
-      } else {
-        return navigate(`/id/${data?._id}/page/${firstPage._id}`);
+      if (defaultPage) {
+        return navigate(`/id/${wiki?._id}/page/${defaultPage._id}`);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, match]);
+  }, [wiki, match, userRights]);
 };

--- a/frontend/src/mocks/index.ts
+++ b/frontend/src/mocks/index.ts
@@ -1,3 +1,4 @@
+import { RightRole } from 'edifice-ts-client';
 import { Revision } from '~/models/revision';
 
 export const mockWiki = {
@@ -115,6 +116,120 @@ export const mockWiki = {
     displayName: 'Author',
   },
   index: '004',
+  rights: [],
+  thumbnail: 'wikiThumbnail.jpg',
+};
+
+export const mockWikiWithHiddenIndexPage = {
+  _id: 'f9853a14b355',
+  title: 'Wiki With Hidden Index Page',
+  pages: [
+    {
+      _id: '001',
+      title: 'ma nouvelle page',
+      content: 'test modification',
+      contentPlain: 'test modification',
+      author: '123456789',
+      authorName: 'Author',
+      modified: {
+        $date: 1718207454421,
+      },
+      lastContributer: '123456789',
+      lastContributerName: 'Author',
+      isVisible: false,
+    },
+    {
+      _id: '002',
+      title: 'aaaa',
+      content: 'rgrgrg aaz',
+      contentPlain: 'rgrgrg aaz',
+      author: '123456789',
+      authorName: 'Author',
+      modified: {
+        $date: 1718207659179,
+      },
+      lastContributer: '123456789',
+      lastContributerName: 'Author',
+      isVisible: false,
+    },
+    {
+      _id: '003',
+      title: 'test gras',
+      content: 'ma super page',
+      contentPlain: 'ma super page',
+      author: '123456789',
+      authorName: 'Author',
+      modified: {
+        $date: 1720193036074,
+      },
+      isVisible: true,
+    },
+  ],
+  modified: {
+    $date: 1718207659179,
+  },
+  owner: {
+    userId: '123456789',
+    displayName: 'Author',
+  },
+  index: '001',
+  rights: [],
+  thumbnail: 'wikiThumbnail.jpg',
+};
+
+export const mockWikiWithOnlyHiddenPages = {
+  _id: 'f9853a14b356',
+  title: 'Wiki With Only Hidden Pages',
+  pages: [
+    {
+      _id: '001',
+      title: 'ma nouvelle page',
+      content: 'test modification',
+      contentPlain: 'test modification',
+      author: '123456789',
+      authorName: 'Author',
+      modified: {
+        $date: 1718207454421,
+      },
+      lastContributer: '123456789',
+      lastContributerName: 'Author',
+      isVisible: false,
+    },
+    {
+      _id: '002',
+      title: 'aaaa',
+      content: 'rgrgrg aaz',
+      contentPlain: 'rgrgrg aaz',
+      author: '123456789',
+      authorName: 'Author',
+      modified: {
+        $date: 1718207659179,
+      },
+      lastContributer: '123456789',
+      lastContributerName: 'Author',
+      isVisible: false,
+    },
+    {
+      _id: '003',
+      title: 'test gras',
+      content: 'ma super page',
+      contentPlain: 'ma super page',
+      author: '123456789',
+      authorName: 'Author',
+      modified: {
+        $date: 1720193036074,
+      },
+      isVisible: false,
+    },
+  ],
+  modified: {
+    $date: 1718207659179,
+  },
+  owner: {
+    userId: '123456789',
+    displayName: 'Author',
+  },
+  index: '001',
   rights: [],
   thumbnail: 'wikiThumbnail.jpg',
 };
@@ -238,3 +353,31 @@ export const mockRevision: Revision[] = [
     },
   },
 ];
+
+export const mockUserCreator: Record<RightRole, boolean> = {
+  creator: true,
+  manager: true,
+  read: true,
+  contrib: true,
+};
+
+export const mockUserManager: Record<RightRole, boolean> = {
+  creator: false,
+  manager: true,
+  read: true,
+  contrib: true,
+};
+
+export const mockUserRead: Record<RightRole, boolean> = {
+  creator: false,
+  manager: false,
+  read: true,
+  contrib: false,
+};
+
+export const mockUserContrib: Record<RightRole, boolean> = {
+  creator: false,
+  manager: false,
+  read: true,
+  contrib: true,
+};

--- a/frontend/src/utils/findDefaultPage.test.ts
+++ b/frontend/src/utils/findDefaultPage.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { findDefaultPage } from './findDefaultPage';
+import {
+  mockUserContrib,
+  mockUserManager,
+  mockUserRead,
+  mockWiki,
+  mockWikiWithHiddenIndexPage,
+  mockWikiWithOnlyHiddenPages,
+} from '~/mocks';
+
+describe('findDefaultPage', () => {
+  it('should return the index page if the user is a manager', () => {
+    const result = findDefaultPage(mockWiki, mockUserManager);
+    expect(result?._id).toBe(mockWiki.index);
+  });
+
+  it('should return the index page if the user is a reader and index page is visible', () => {
+    const result = findDefaultPage(mockWiki, mockUserRead);
+    expect(result?._id).toBe(mockWiki.index);
+  });
+
+  it('should return the first visible page if the index page is not visible and user is not manager', () => {
+    const firstVisiblePageId = '003';
+    const result = findDefaultPage(
+      mockWikiWithHiddenIndexPage,
+      mockUserContrib
+    );
+    expect(result?._id).toBe(firstVisiblePageId);
+  });
+
+  it('should return the index page if the user is a manager and the index page is not visible', () => {
+    const result = findDefaultPage(
+      mockWikiWithHiddenIndexPage,
+      mockUserManager
+    );
+    expect(result?._id).toBe(mockWikiWithHiddenIndexPage.index);
+  });
+
+  it('should return undefined if no visible page is found and user is not a manager', () => {
+    const result = findDefaultPage(mockWikiWithOnlyHiddenPages, mockUserRead);
+    expect(result).toBeUndefined();
+  });
+});

--- a/frontend/src/utils/findDefaultPage.ts
+++ b/frontend/src/utils/findDefaultPage.ts
@@ -1,0 +1,20 @@
+import { RightRole } from 'edifice-ts-client';
+import { Page, Wiki } from '~/models';
+
+type UserRights = Record<RightRole, boolean>;
+
+export const findDefaultPage = (
+  wiki: Wiki,
+  userRights: UserRights
+): Page | undefined => {
+  const { pages, index } = wiki;
+  const indexPage = pages.find((page) => page._id === index);
+
+  // Return the index page if the user is a manager or if it's visible.
+  if (indexPage && (userRights.manager || indexPage.isVisible)) {
+    return indexPage;
+  }
+
+  // Return the first page if user is a manager or the first visible page
+  return userRights.manager ? pages[0] : pages.find((page) => page.isVisible);
+};


### PR DESCRIPTION
## Describe your changes

Redirect to a visible default page:

La page par défaut après avoir cliqué sur un wiki doit être visible si l’utilisateur n'est pas un gestionnaire.

Si l’utilisateur est un gestionnaire on affiche la page par défaut peu importe la visiblité.

Si le wiki n’a pas de page par défaut on affiche la première page pour un gestionnaire et la première page visible pour un non gestionnaire.

Si aucune page ne correspond à ces critères, on affiche la page empty screen du wiki.

## Checklist tests

## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

