### PR TITLE
fix: #WB2-2003, put route GET /wiki/listallpages back

### DIFF
--- a/backend/src/main/java/net/atos/entng/wiki/controllers/WikiController.java
+++ b/backend/src/main/java/net/atos/entng/wiki/controllers/WikiController.java
@@ -214,6 +214,21 @@ public class WikiController extends MongoDbControllerHelper {
 		wikiService.getPages(idWiki, getContent, handler);
 	}
 
+	@Get("/listallpages")
+	@ApiDoc("List wikis, visible by current user, with all their pages' titles. Used by Behaviours.")
+	@SecuredAction("wiki.list")
+	public void listAllPages(final HttpServerRequest request) {
+		UserUtils.getUserInfos(eb, request, new Handler<UserInfos>() {
+			@Override
+			public void handle(final UserInfos user) {
+				if (user != null) {
+					Handler<Either<String, JsonArray>> handler = arrayResponseHandler(request);
+					wikiService.listAllPages(user, handler);
+				}
+			}
+		});
+	}
+
 	// TODO: add a print param to true in GET /wiki/:id to get all information to print a wiki?
 	/*@Get("/:id/whole")
 	@ApiDoc("Get a wiki with all its pages. Used to print a wiki")

--- a/backend/src/main/java/net/atos/entng/wiki/service/WikiService.java
+++ b/backend/src/main/java/net/atos/entng/wiki/service/WikiService.java
@@ -56,6 +56,8 @@ public interface WikiService {
 	public void getPages(String idWiki, String getContent,
 						 Handler<Either<String, JsonObject>> handler);
 
+	public void listAllPages(UserInfos user, Handler<Either<String, JsonArray>> handler);
+
 	public void createPage(UserInfos user, String wikiId, JsonObject page, HttpServerRequest request
 			, Handler<Either<String, JsonObject>> handler);
 

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -6,6 +6,7 @@ import {
   mockWiki,
   mockWikiPagesWithoutContent,
   mockWikis,
+  mockWikisWithPages,
 } from '.';
 
 const defaultHandlers = [
@@ -235,6 +236,9 @@ const defaultHandlers = [
  */
 export const handlers = [
   ...defaultHandlers,
+  http.get(`${baseURL}/listallpages`, () => {
+    return HttpResponse.json(mockWikisWithPages, { status: 200 });
+  }),
   http.get(`${baseURL}/list`, () => {
     return HttpResponse.json(mockWikis, { status: 200 });
   }),

--- a/frontend/src/mocks/index.ts
+++ b/frontend/src/mocks/index.ts
@@ -303,6 +303,75 @@ export const mockWikis = [
   },
 ];
 
+export const mockWikisWithPages = [
+  {
+    _id: '423a3e89',
+    title: 'Définitions Espanol',
+    pages: [
+      {
+        _id: '5540ede1e4b056471c495282',
+        title: 'Acaparar',
+        author: 'b6db229d',
+        authorName: 'Author',
+        modified: {
+          $date: 1430318586054,
+        },
+        contentPlain: '',
+      },
+      {
+        _id: '5540eec6e4b056471c495283',
+        title: 'Resultar',
+        author: '13f1e9f7',
+        authorName: 'Author',
+        modified: {
+          $date: 1501842229907,
+        },
+        contentPlain: '',
+      },
+      {
+        _id: '5540ef0fe4b056471c495284',
+        title: 'Lechería',
+        author: 'b6db229d',
+        authorName: 'Author',
+        modified: {
+          $date: 1430318863835,
+        },
+        contentPlain: '',
+      },
+      {
+        _id: '580f3f8ee4b07ac1b023b2db',
+        title: 'Accueil',
+        contentPlain: '',
+        author: 'a87b39c0',
+        authorName: 'Author',
+        modified: {
+          $date: 1478192151290,
+        },
+      },
+      {
+        _id: '657974cc736a590490395b4b',
+        title: 'Titre',
+        contentPlain: '',
+        author: '219a1774',
+        authorName: 'Author',
+        modified: {
+          $date: 1702458572178,
+        },
+      },
+    ],
+    owner: {
+      userId: 'b6db229d',
+      displayName: 'Author',
+    },
+    modified: {
+      $date: 1501842229907,
+      thumbnail: '',
+      shared: [],
+      index: '580f3f8ee4b07ac1b023b2db',
+    },
+  },
+];
+
 export const mockWikiPages = {
   pages: [
     {

--- a/frontend/src/services/api/index.test.ts
+++ b/frontend/src/services/api/index.test.ts
@@ -4,6 +4,7 @@ import {
   mockWiki,
   mockWikiPagesWithoutContent,
   mockWikis,
+  mockWikisWithPages,
 } from '~/mocks';
 import { wikiService } from '..';
 
@@ -14,6 +15,13 @@ describe('Wiki GET Methods', () => {
     expect(response).toBeDefined();
     expect(response).toHaveLength(2);
     expect(response).toStrictEqual(mockWikis);
+  });
+
+  test('makes a GET request to get all wikis with pages', async () => {
+    const response = await wikiService.getAllWikisWithPages();
+
+    expect(response).toBeDefined();
+    expect(response).toStrictEqual(mockWikisWithPages);
   });
 
   test('makes a GET request to get one wiki with pages', async () => {

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -55,6 +55,17 @@ const createWikiService = (baseURL: string) => ({
 
   /**
    *
+   * @returns all wikis with pages
+   */
+  async getAllWikisWithPages() {
+    const response = await odeServices
+      .http()
+      .get<Wiki[]>(`${baseURL}/listallpages`);
+    return response;
+  },
+
+  /**
+   *
    * @param wikiId string
    * @param pageId string
    * @returns get a page of a wiki by id

--- a/frontend/src/services/queries/page/page.ts
+++ b/frontend/src/services/queries/page/page.ts
@@ -143,6 +143,9 @@ export const useCreatePage = () => {
       queryClient.invalidateQueries({
         queryKey: wikiQueryOptions.findAll().queryKey,
       });
+      queryClient.invalidateQueries({
+        queryKey: wikiQueryOptions.findAllWithPages().queryKey,
+      });
     },
   });
 };
@@ -167,6 +170,9 @@ export const useUpdatePage = () => {
       queryClient.invalidateQueries({
         queryKey: pageQueryOptions.findOne({ wikiId, pageId }).queryKey,
       });
+      queryClient.invalidateQueries({
+        queryKey: wikiQueryOptions.findAllWithPages().queryKey,
+      });
     },
   });
 };
@@ -182,6 +188,9 @@ export const useDeletePage = () => {
       });
       queryClient.removeQueries({
         queryKey: pageQueryOptions.findOne({ wikiId, pageId }).queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: wikiQueryOptions.findAllWithPages().queryKey,
       });
     },
   });

--- a/frontend/src/services/queries/wiki/wiki.test.tsx
+++ b/frontend/src/services/queries/wiki/wiki.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { useGetWiki, useGetWikis } from './wiki';
+import { useGetAllWikisWithPages, useGetWiki, useGetWikis } from './wiki';
 
-import { mockWiki, mockWikis } from '~/mocks';
+import { mockWiki, mockWikis, mockWikisWithPages } from '~/mocks';
 import { wrapper } from '~/mocks/setup';
 
 describe('Wiki GET Queries', () => {
@@ -15,6 +15,15 @@ describe('Wiki GET Queries', () => {
       expect(result.current.data).toBeDefined();
       expect(result.current.data).toEqual(mockWikis);
     });
+  });
+
+  test('use useGetAllWikisWithPages to get all wikis with pages', async () => {
+    const { result } = renderHook(() => useGetAllWikisWithPages(), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeDefined();
+    expect(result.current.data).toEqual(mockWikisWithPages);
   });
 
   test('use useGetWiki hook to get one wiki', async () => {

--- a/frontend/src/services/queries/wiki/wiki.ts
+++ b/frontend/src/services/queries/wiki/wiki.ts
@@ -12,6 +12,12 @@ export const wikiQueryOptions = {
       queryFn: wikiService.getWikis,
       staleTime: 5000,
     }),
+  findAllWithPages: () =>
+    queryOptions({
+      queryKey: [...wikiQueryOptions.base, 'listallpages'] as const,
+      queryFn: wikiService.getAllWikisWithPages,
+      staleTime: 5000,
+    }),
   findOne: (wikiId: string) =>
     queryOptions({
       queryKey: [...wikiQueryOptions.base, { id: wikiId }] as const,
@@ -26,6 +32,10 @@ export const wikiQueryOptions = {
 
 export const useGetWikis = () => {
   return useQuery(wikiQueryOptions.findAll());
+};
+
+export const useGetAllWikisWithPages = () => {
+  return useQuery(wikiQueryOptions.findAllWithPages());
 };
 
 export const useGetWiki = (wikiId: string) => {


### PR DESCRIPTION
## Describe your changes

Put the route GET /wiki/listallpages back because it is used by the Behaviours..

## Checklist tests

## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

