### PR TITLE
fix: #WB2-2085, flatten children list

### DIFF
--- a/frontend/src/hooks/useFeedData.ts
+++ b/frontend/src/hooks/useFeedData.ts
@@ -4,6 +4,7 @@ import { Page } from '~/models';
 import { useGetWiki } from '~/services';
 import { useTreeActions } from '~/store';
 import { useFilterVisiblePage } from './useFilterVisiblePage';
+import { getChildrenRecursively } from '~/utils/getChildrenRecursively';
 
 export const useFeedData = () => {
   const params = useParams();
@@ -20,16 +21,15 @@ export const useFeedData = () => {
         .filter((page) => filterParentPage(page) && filterVisiblePage(page))
         .map((page) => {
           if (page.children) {
-            const childPages = page.children
-              .filter((child) => filterVisiblePage(child as Page))
-              .map((child) => {
-                return {
-                  id: child._id,
-                  name: child.title,
-                  isVisible: child.isVisible,
-                  position: child.position,
-                };
-              });
+            //TODO instead of flattening the tree, we should break parent children relationship at level 2 when moving a page
+            // Get all children of the page recursively (flatten the tree because we display only 2 levels)
+            const childPages = Object.values(
+              getChildrenRecursively({
+                page,
+                filterPage: filterVisiblePage,
+                allPages: data.pages,
+              }),
+            );
             return {
               id: page._id,
               name: page.title,

--- a/frontend/src/utils/getChildrenRecursively.ts
+++ b/frontend/src/utils/getChildrenRecursively.ts
@@ -1,0 +1,76 @@
+import { flattenTree, TreeItem } from '@edifice-ui/react';
+import { Page } from '~/models';
+type Child = {
+  id: string;
+  name: string;
+  isVisible: boolean;
+  position: number | undefined;
+};
+/**
+ * Get all children of a page recursively (flatten the tree)
+ * - Direct children
+ * - Children of children
+ * - Orphans (children of the page that have parentId equal to the page id)
+ */
+export const getChildrenRecursively = ({
+  page,
+  allPages,
+  filterPage,
+}: {
+  page: Page;
+  allPages: Page[];
+  filterPage: (page: Page) => boolean;
+}): Record<string, Child> => {
+  const pageByIds: Record<string, Page> = {};
+  // Transform a page to a tree item recursively
+  const transformToTreeItemRecursively = (parent: Page): TreeItem => {
+    pageByIds[parent._id] = parent;
+    return {
+      id: parent._id,
+      name: parent.title,
+      isVisible: parent.isVisible,
+      position: parent.position,
+      children:
+        parent.children?.map((page) =>
+          transformToTreeItemRecursively(page as Page),
+        ) ?? [],
+    };
+  };
+  // Flatten the tree
+  const tree = flattenTree([transformToTreeItemRecursively(page)], page._id);
+  // List of all children
+  let allChildren: Record<string, Child> = {};
+  // Add descendants to the list if filterPage is true
+  for (const child of tree) {
+    const page = pageByIds[child.id];
+    if (filterPage(page)) {
+      allChildren[page._id] = {
+        id: page._id,
+        name: page.title,
+        isVisible: page.isVisible,
+        position: page.position,
+      };
+    }
+  }
+  // Check if the child is in the allPages list
+  const orphans = allPages.filter((p) => p.parentId === page._id);
+  for (const orphan of orphans) {
+    // add orphan to the list
+    allChildren[orphan._id] = {
+      id: orphan._id,
+      name: orphan.title,
+      isVisible: orphan.isVisible,
+      position: orphan.position,
+    };
+    // Recursively add children of orphans
+    allChildren = {
+      ...allChildren,
+      ...getChildrenRecursively({
+        page: orphan,
+        allPages,
+        filterPage,
+      }),
+    };
+  }
+  return allChildren;
+};


### PR DESCRIPTION
# Description

Ce fix applatie la hierarchie de pages car on ne peut afficher que 2 niveaux de pages (certaines opérations comme le déplacement peuvent créer 3 niveaux)
Ce fix récupère les pages orphelines (qui ont un parent devenu enfant) ou les pages de niveaux supérieurs à 2
Sur le moyen terme il faudrait revoir certaines API pour casser les liens parents enfants (lors du déplacement par exemple)

>

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
