### PR TITLE
fix: #WB2-2047, keep same visibility while moving

### DIFF
--- a/backend/src/main/java/net/atos/entng/wiki/service/WikiServiceMongoImpl.java
+++ b/backend/src/main/java/net/atos/entng/wiki/service/WikiServiceMongoImpl.java
@@ -627,6 +627,7 @@ public class WikiServiceMongoImpl extends MongoDbCrudService implements WikiServ
 			final JsonObject criteria = new JsonObject().put("_id", idWiki).put("pages._id", entry.getId());
 			final JsonObject set = new MongoUpdateBuilder()
 					.set("pages.$.position", entry.getPosition())
+					.set("pages.$.isVisible", entry.getIsVisible())
 					.set("pages.$.parentId", entry.getParentId()).build();
 			commmands.add(new JsonObject().put("operation", "update").put("document", set).put("criteria", criteria));
 		}

--- a/backend/src/main/java/net/atos/entng/wiki/to/PageListEntryFlat.java
+++ b/backend/src/main/java/net/atos/entng/wiki/to/PageListEntryFlat.java
@@ -12,16 +12,18 @@ public class PageListEntryFlat {
     private final String id;
     private final Integer position;
     private final String parentId;
+    private final Boolean isVisible;
 
-    public PageListEntryFlat(String id, Integer position) {
-        this(id, position, null);
+    public PageListEntryFlat(String id, Integer position, Boolean isVisible) {
+        this(id, position, null, isVisible);
     }
 
     @JsonCreator
-    public PageListEntryFlat(@JsonProperty("_id")  String id, @JsonProperty("position") Integer position, @JsonProperty("parentId") String parentId) {
+    public PageListEntryFlat(@JsonProperty("_id")  String id, @JsonProperty("position") Integer position, @JsonProperty("parentId") String parentId, @JsonProperty("isVisible") Boolean isVisible) {
         this.id = id;
         this.position = position;
         this.parentId = parentId;
+        this.isVisible = isVisible;
     }
 
     public boolean hasParentId(final String id){
@@ -42,6 +44,10 @@ public class PageListEntryFlat {
 
     public String getParentId() {
         return parentId;
+    }
+
+    public Boolean getIsVisible() {
+        return isVisible;
     }
 
     public JsonObject toJson(){

--- a/backend/src/main/java/net/atos/entng/wiki/to/PageListEntryTree.java
+++ b/backend/src/main/java/net/atos/entng/wiki/to/PageListEntryTree.java
@@ -15,28 +15,31 @@ public class PageListEntryTree {
     private final String id;
     private final Integer position;
     private final String parentId;
+    private final Boolean isVisible;
     private final List<PageListEntryTree> childrens;
 
     public PageListEntryTree(PageListEntryFlat entry) {
-        this(entry.getId(), entry.getPosition(), entry.getParentId(), new ArrayList<>());
+        this(entry.getId(), entry.getPosition(), entry.getParentId(), entry.getIsVisible(), new ArrayList<>());
     }
 
-    public PageListEntryTree(String _id, Integer position) {
-        this(_id, position, null, Collections.emptyList());
+    public PageListEntryTree(String _id, Integer position, Boolean isVisible) {
+        this(_id, position, null, isVisible, Collections.emptyList());
     }
 
-    public PageListEntryTree(String id, Integer position, List<PageListEntryTree> childrens) {
-        this(id, position, null, childrens);
+    public PageListEntryTree(String id, Integer position, Boolean isVisible, List<PageListEntryTree> childrens) {
+        this(id, position, null, isVisible, childrens);
     }
 
     @JsonCreator
     public PageListEntryTree(@JsonProperty("_id") String _id,
                              @JsonProperty("position") Integer position,
                              @JsonProperty("parentId") String parentId,
+                             @JsonProperty("isVisible") Boolean isVisible,
                              @JsonProperty("childrens") List<PageListEntryTree> childrens) {
         this.id = _id;
         this.position = position;
         this.parentId = parentId;
+        this.isVisible = isVisible;
         this.childrens = childrens;
     }
 
@@ -59,6 +62,10 @@ public class PageListEntryTree {
 
     public String getParentId() {
         return parentId;
+    }
+
+    public Boolean getIsVisible() {
+        return isVisible;
     }
 
     public JsonObject toJson(){

--- a/backend/src/main/resources/jsonschema/pageUpdateList.json
+++ b/backend/src/main/resources/jsonschema/pageUpdateList.json
@@ -16,6 +16,9 @@
           },
           "parentId": {
             "type": "string"
+          },
+          "isVisible": {
+            "type": "boolean"
           }
         },
         "required": ["_id", "position"]

--- a/frontend/src/hooks/useUpdatePages.ts
+++ b/frontend/src/hooks/useUpdatePages.ts
@@ -1,0 +1,61 @@
+import { useCallback } from 'react';
+import { wikiService } from '~/services/api';
+import { useGetPagesFromWiki } from '~/services';
+import { UpdateTreeData } from '@edifice-ui/react';
+
+export const useUpdatePages = (wikiId: string) => {
+  const { data: originalPages } = useGetPagesFromWiki({
+    wikiId,
+    content: true,
+  });
+  const handleSortPage = useCallback(
+    async (pages: UpdateTreeData[]) => {
+      try {
+        //TODO backend should handle this with custom api for moving pages
+        // Process each page
+        for (const page of pages) {
+          // Get the original page
+          const originalPage = originalPages?.find((p) => p._id === page._id);
+          // Keep the same visibility by default
+          if (originalPage) {
+            page.isVisible = originalPage.isVisible;
+          }
+          // Get the parent page if it exists
+          if (page.parentId) {
+            const parentPage = originalPages?.find(
+              (p) => p._id === page.parentId,
+            );
+            // Update the visibility of the page if the parent page is not visible
+            if (parentPage && !parentPage.isVisible) {
+              page.isVisible = false;
+            }
+            // else keep the same visibility
+          }
+        }
+
+        // Update all pages with their new visibilities
+        if (pages.length > 0) {
+          await wikiService.updatePages({
+            wikiId,
+            data: {
+              pages: pages.map((page) => ({
+                _id: page._id,
+                parentId: page.parentId!,
+                isVisible: page.isVisible ?? false,
+                position: page.position ?? 0,
+              })),
+            },
+          });
+        }
+
+        return true;
+      } catch (error) {
+        console.error('Error updating pages visibility:', error);
+        return false;
+      }
+    },
+    [wikiId, originalPages],
+  );
+
+  return { handleSortPage };
+};

--- a/frontend/src/routes/wiki/index.tsx
+++ b/frontend/src/routes/wiki/index.tsx
@@ -30,7 +30,7 @@ import { useFeedData } from '~/hooks/useFeedData';
 import { useIsOnlyRead } from '~/hooks/useIsOnlyRead';
 import { useMenu } from '~/hooks/useMenu';
 import { useRedirectDefaultPage } from '~/hooks/useRedirectDefaultPage';
-import { useGetWiki, wikiQueryOptions, wikiService } from '~/services';
+import { useGetWiki, wikiQueryOptions } from '~/services';
 import { getUserRightsActions } from '~/store';
 import { useToastActions, useToastMessages } from '~/store/toast';
 import {
@@ -39,6 +39,7 @@ import {
   useTreeData,
 } from '~/store/treeview';
 import './index.css';
+import { useUpdatePages } from '~/hooks/useUpdatePages';
 
 export const loader =
   (queryClient: QueryClient) =>
@@ -71,6 +72,7 @@ export const Index = () => {
   const isOnlyRead = useIsOnlyRead();
   const toastMessages = useToastMessages();
   const toast = useToast();
+  const { handleSortPage } = useUpdatePages(params.wikiId!);
 
   const { t } = useTranslation('wiki');
   const { clearToastMessages } = useToastActions();
@@ -190,12 +192,7 @@ export const Index = () => {
                     )}
                   </div>
                 )}
-                onSortable={async (updateArray) => {
-                  await wikiService.updatePages({
-                    wikiId: params.wikiId!,
-                    data: { pages: updateArray },
-                  });
-                }}
+                onSortable={(pages) => handleSortPage(pages)}
                 onTreeItemClick={handleOnTreeItemClick}
               />
             )}


### PR DESCRIPTION
# Description

Ce fix permet de rendre une page invisible si la page de destination est invisible lorsqu'on opère un déplacement.
Ainsi une page enfant devient invisible si elle est déplacé dans une page invisible et si elle reste inchangé si elle est déplacé dans une page visible.
A terme cela devra être géré par une route back dédié au déplacement avec les règles métiers spécifiques à cette opération

>

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
