### PR TITLE
feat: #wb2-1524, add recursive page duplication and target multiple wiki

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <web-utils.version></web-utils.version>
         <mongodb-helper.version></mongodb-helper.version>
-        <entcore.version>6.1-develop-pedago-SNAPSHOT</entcore.version>
+        <entcore.version>6.0-develop-pedago-SNAPSHOT</entcore.version>
     </properties>
 
     <repositories>

--- a/backend/src/main/java/net/atos/entng/wiki/service/WikiService.java
+++ b/backend/src/main/java/net/atos/entng/wiki/service/WikiService.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpServerRequest;
+import net.atos.entng.wiki.to.PageId;
 import net.atos.entng.wiki.to.PageListRequest;
 import net.atos.entng.wiki.to.PageListResponse;
 import org.entcore.common.user.UserInfos;
@@ -109,4 +110,13 @@ public interface WikiService {
 
 	public void deleteRevisions(String wikiId, String pageId, Handler<Either<String, JsonObject>> handler);
 
+	/**
+	 * Duplicate a page to multiple wikis
+	 * @param user the user
+	 * @param sourceWikiId the source wiki ID
+	 * @param sourcePageId the source page ID
+	 * @param targetWikiIdList the list of target wiki IDs
+	 * @return the list of new page IDs
+	 */
+	Future<List<PageId>> duplicatePage(UserInfos user, String sourceWikiId, String sourcePageId, List<String> targetWikiIdList);
 }

--- a/backend/src/main/java/net/atos/entng/wiki/service/WikiServiceMongoImpl.java
+++ b/backend/src/main/java/net/atos/entng/wiki/service/WikiServiceMongoImpl.java
@@ -37,10 +37,12 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import net.atos.entng.wiki.explorer.WikiExplorerPlugin;
+import net.atos.entng.wiki.to.PageId;
 import net.atos.entng.wiki.to.PageListEntryFlat;
 import net.atos.entng.wiki.to.PageListRequest;
 import net.atos.entng.wiki.to.PageListResponse;
 import org.bson.conversions.Bson;
+import org.bson.types.ObjectId;
 import org.entcore.common.explorer.IdAndVersion;
 import org.entcore.common.mongodb.MongoDbResult;
 import org.entcore.common.service.impl.MongoDbCrudService;
@@ -1035,6 +1037,127 @@ public class WikiServiceMongoImpl extends MongoDbCrudService implements WikiServ
 			query = and(query, eq("pageId", pageId));
 		}
 		mongo.delete(REVISIONS_COLLECTION, MongoQueryBuilder.build(query), MongoDbResult.validResultHandler(handler));
+	}
+
+	@Override
+	public Future<List<PageId>> duplicatePage(UserInfos user, String sourceWikiId, String sourcePageId, List<String> targetWikiIdList) {
+		final Promise<List<PageId>> globalPromise = Promise.promise();
+		final List<PageId> duplicatedPageIds = new ArrayList<>();
+
+		// Get the source wiki
+		getWiki(sourceWikiId, sourceWikiRes -> {
+			// If the source wiki is not found, return an error
+			if (sourceWikiRes.isLeft()) {
+				globalPromise.fail("wiki.source.not.found");
+				return;
+			}
+			// Get the source wiki
+			final JsonObject sourceWiki = sourceWikiRes.right().getValue();
+			// Get the source pages
+			final JsonArray pages = sourceWiki.getJsonArray("pages", new JsonArray());
+
+			// Find the source page
+			final Optional<Object> sourcePageOpt = pages.stream()
+					.filter(p -> sourcePageId.equals(((JsonObject)p).getString("_id")))
+					.findFirst();
+
+			if (!sourcePageOpt.isPresent()) {
+				globalPromise.fail("wiki.page.source.not.found");
+				return;
+			}
+			// Get the source page
+			final JsonObject sourcePage = (JsonObject) sourcePageOpt.get();
+			// Get the source subpages
+			final JsonArray sourceSubPages = getSubPages(sourceWiki, Collections.singleton(sourcePageId));
+
+			// Create futures for each target wiki
+			final List<Future<Void>> futures = new ArrayList<>();
+			for (String targetWikiId : targetWikiIdList) {
+				// Generate a new page ID
+				final String newPageId = new ObjectId().toString();
+				// Add the new page ID to the list of duplicated page IDs
+				duplicatedPageIds.add(new PageId(newPageId, targetWikiId));
+
+				// Duplicate the page
+				final JsonObject newPage = sourcePage.copy();
+				// Set the new page properties
+				newPage.put("_id", newPageId)
+					   .put("author", user.getUserId())
+					   .put("authorName", user.getUsername())
+					   .put("created", MongoDb.now())
+					   .put("modified", MongoDb.now())
+					   .put("contentVersion", 1)
+					   .remove("parentId");
+
+				// Duplicate subpages
+				final JsonArray newSubPages = new JsonArray();
+				if (!sourceSubPages.isEmpty()) {
+					final JsonArray newChildren = new JsonArray();
+					for (Object subPage : sourceSubPages) {
+						// Get the source subpage
+						final JsonObject sourceSubPage = (JsonObject) subPage;
+						// Duplicate the source subpage
+						final JsonObject newSubPage = sourceSubPage.copy();
+						// Generate a new subpage ID
+						final String newSubPageId = new ObjectId().toString();
+						// Set the new subpage properties
+						newSubPage.put("_id", newSubPageId)
+								 .put("parentId", newPageId)
+								 .put("author", user.getUserId())
+								 .put("authorName", user.getUsername())
+								 .put("created", MongoDb.now())
+								 .put("modified", MongoDb.now())
+								 .put("contentVersion", 1);
+						// Add the new subpage to the new subpages array
+						newSubPages.add(newSubPage);
+						// Add child reference to parent page
+						final JsonObject child = new JsonObject()
+								.put("_id", newSubPageId)
+								.put("title", newSubPage.getString("title"))
+								.put("isVisible", newSubPage.getBoolean("isVisible"))
+								.put("position", newSubPage.getInteger("position"));
+						newChildren.add(child);
+					}
+					// Add children array to parent page
+					newPage.put("children", newChildren);
+				}
+
+				// Add the page and its subpages to the target wiki
+				final Bson query = eq("_id", targetWikiId);
+				// Create a JsonArray with all pages to add
+				final JsonArray allPages = new JsonArray().add(newPage);
+				allPages.addAll(newSubPages);
+
+				// Create the query with JsonObject
+				final JsonObject update = new JsonObject()
+					.put("$push", new JsonObject()
+						.put("pages", new JsonObject()
+							.put("$each", allPages)
+						)
+					);
+
+				// Create a future for the target wiki
+				final Future<Void> future = Future.future(updatePromise -> {
+					// Update the target wiki
+					mongo.update(collection, MongoQueryBuilder.build(query), update, res -> {
+						if ("ok".equals(res.body().getString("status"))) {
+							updatePromise.complete();
+						} else {
+							updatePromise.fail(res.body().getString("message"));
+						}
+					});
+				});
+				// Add the future to the list of futures
+				futures.add(future);
+			}
+
+			// Wait for all duplications to be completed
+			Future.all(futures)
+				.onSuccess(res -> globalPromise.complete(duplicatedPageIds))
+				.onFailure(err -> globalPromise.fail(err.getMessage()));
+		});
+
+		return globalPromise.future();
 	}
 
 	/**

--- a/backend/src/main/java/net/atos/entng/wiki/to/PageId.java
+++ b/backend/src/main/java/net/atos/entng/wiki/to/PageId.java
@@ -1,0 +1,34 @@
+package net.atos.entng.wiki.to;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.vertx.core.json.JsonObject;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PageId {
+    private final String pageId;
+    private final String wikiId;
+
+    @JsonCreator
+    public PageId(@JsonProperty("pageId") String pageId, @JsonProperty("wikiId") String wikiId) {
+        this.pageId = pageId;
+        this.wikiId = wikiId;
+    }
+
+    public String getPageId() {
+        return pageId;
+    }
+
+    public String getWikiId() {
+        return wikiId;
+    }
+
+    public JsonObject toJson() {
+        return JsonObject.mapFrom(this);
+    }
+
+    public static PageId fromJson(final JsonObject json) {
+        return json.mapTo(PageId.class);
+    }
+}

--- a/frontend/src/features/page/DuplicateModal/DuplicateModal.test.tsx
+++ b/frontend/src/features/page/DuplicateModal/DuplicateModal.test.tsx
@@ -127,12 +127,9 @@ describe('DuplicateModal component', () => {
     // Wait for the mutation to be called
     await waitFor(() => {
       expect(mockMutateAsync).toHaveBeenCalledWith({
-        destinationWikiId: 'wiki2', // Assuming 'wiki2' is the selected wiki
-        data: {
-          content: '',
-          isVisible: mockWikiPages.pages[0].isVisible,
-          title: mockWikiPages.pages[0].title,
-        },
+        sourceWikiId: 'wiki1',
+        sourcePageId: 'page1',
+        targetWikiIds: ['wiki2'],
       });
     });
   });

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -291,4 +291,10 @@ export const handlers = [
       { status: 200 },
     );
   }),
+  http.post(`${baseURL}/:wikiId/page/:pageId/duplicate`, () => {
+    return HttpResponse.json(
+      { newPageIds: [{ wikiId: mockPage._id, pageId: mockPage.pages[0]._id }] },
+      { status: 200 },
+    );
+  }),
 ];

--- a/frontend/src/models/page.ts
+++ b/frontend/src/models/page.ts
@@ -82,4 +82,17 @@ export type DuplicatePagePayload = Pick<
   'title' | 'content' | 'isVisible' | 'position'
 >;
 
+export type DuplicatePageResult = {
+  newPageIds: Array<{
+    pageId: string;
+    wikiId: string;
+  }>;
+};
+
+export type DuplicatePageResultOrError =
+  | DuplicatePageResult
+  | {
+      error: string;
+    };
+
 export type PickedPageId = Pick<Page, '_id' | 'error'>;

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -1,12 +1,11 @@
 import { odeServices } from '@edifice.io/client';
 import {
-  DuplicatePagePayload,
+  DuplicatePageResultOrError,
   Page,
   PageDto,
   PagePostPayload,
   PagePutPayload,
   PagesPutPayload,
-  PickedPageId,
   PickedWiki,
   Wiki,
   WikiDto,
@@ -322,22 +321,28 @@ const createWikiService = (baseURL: string) => ({
   /**
    * Duplicate a page
    *
-   * @param {Object} params - expected params to duplicate a page.
    * @param {string} params.sourceWikiId - source wiki id.
-   * @param {string} params.destinationWikiId - destination wiki id.
-   * @param {DuplicatePagePayload} params.data - data for the new page.
-   * @returns {Promise<Page>} a promise that resolves to the newly created page.
+   * @param {string} params.sourcePageId - source page id.
+   * @param {string[]} params.targetWikiIds - target wiki ids.
+   * @returns {Promise<PickedPageId[]>} a promise that resolves to the newly created page.
    */
   async duplicatePage({
-    destinationWikiId,
-    data,
+    sourceWikiId,
+    sourcePageId,
+    targetWikiIds,
   }: {
-    destinationWikiId: string;
-    data: DuplicatePagePayload;
-  }) {
+    sourceWikiId: string;
+    sourcePageId: string;
+    targetWikiIds: string[];
+  }): Promise<DuplicatePageResultOrError> {
     const response = await odeServices
       .http()
-      .post<PickedPageId>(`${baseURL}/${destinationWikiId}/page`, data);
+      .post<DuplicatePageResultOrError>(
+        `${baseURL}/${sourceWikiId}/page/${sourcePageId}/duplicate`,
+        {
+          targetWikiIds,
+        },
+      );
     return response;
   },
 });

--- a/frontend/src/services/queries/page/page.test.tsx
+++ b/frontend/src/services/queries/page/page.test.tsx
@@ -187,13 +187,9 @@ describe('Wiki Page mutations Queries', () => {
     const { result } = renderHook(() => useDuplicatePage(), { wrapper });
     // prepare the mock
     const variables = {
-      destinationWikiId: 'destinationWikiId',
-      data: {
-        title: 'Duplicated Page',
-        content: 'duplicated content',
-        isVisible: true,
-        position: 0,
-      },
+      sourceWikiId: mockPage._id,
+      sourcePageId: mockPage.pages[0]._id,
+      targetWikiIds: [mockPage._id],
     };
     // execute the mutation
     act(() => {
@@ -203,11 +199,13 @@ describe('Wiki Page mutations Queries', () => {
     await waitFor(() => {
       // check the result
       expect(result.current.isSuccess).toBe(true);
-      expect(result.current.data).toStrictEqual(variables.data);
+      expect(result.current.data).toStrictEqual({
+        newPageIds: [{ wikiId: mockPage._id, pageId: mockPage.pages[0]._id }],
+      });
       // check the invalidations
       expect(invalidateQueriesSpy).toHaveBeenCalledWith({
         queryKey: pageQueryOptions.findAllFromWiki({
-          wikiId: 'destinationWikiId',
+          wikiId: mockPage._id,
           content: true,
         }).queryKey,
       });
@@ -215,7 +213,7 @@ describe('Wiki Page mutations Queries', () => {
         queryKey: wikiQueryOptions.findAllWithPages().queryKey,
       });
       expect(invalidateQueriesSpy).toHaveBeenCalledWith({
-        queryKey: wikiQueryOptions.findOne('destinationWikiId').queryKey,
+        queryKey: wikiQueryOptions.findOne(mockPage._id).queryKey,
       });
     });
   });


### PR DESCRIPTION
# Description

Cette feature ajoute la possibilité de dupliquer une page avec ses sous pages et de le faire vers plusieurs wiki de destination (en ouvrant 1 onglet par wiki de destination)

>

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
